### PR TITLE
Implement grouping by type, side navigation and search with autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   },
   "dependencies": {
     "marked": "^0.3.5",
+	"react-typeahead": "^2.0.0-alpha.5",
     "request": "^2.74.0",
     "yargs": "^5.0.0"
   },

--- a/src/components/SchemaDocsView.css
+++ b/src/components/SchemaDocsView.css
@@ -1,10 +1,82 @@
 @import "./_normalize.css";
 
 .wrapper {
-    display: flex;
-    justify-content: center;
+    height: 100vh;
 }
 
 .container {
-    max-width: 800px;
+    padding-right: 10%;
+    padding-left: 10%;
+}
+
+.content {
+    display: flex;
+    justify-content: center;
+    margin-left: 270px;
+}
+
+.sidenav {
+    position: fixed;
+    overflow-y: scroll;
+    top: 0;
+    bottom: 0;
+    left: 0;
+    width: 250px;
+}
+
+.sidenav::-webkit-scrollbar
+{
+    width: 12px;
+    background-color: #f1f1f1;
+}
+
+.sidenav::-webkit-scrollbar-thumb
+{
+    border-radius: 10px;
+    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,.3);
+    background-color: #d0d0d0;
+}
+
+.selectInput {
+    display: block;
+    border-radius: 10px;
+    border: 2px solid darkgray;
+    color: darkgray;
+    width: 220px;
+    font-size: 1rem;
+    padding: 10px;
+    margin: 20px 10px 0 10px;
+}
+
+.selectInput:hover,
+.selectInput:focus
+{
+    outline: none;
+}
+
+.selectList {
+    list-style: none;
+    margin:0;
+    padding:0;
+}
+
+.selectItem {
+    padding: 3px 3px 3px 18px;
+    width: 100%;
+}
+
+.selectItem:hover {
+    background: lightgray;
+}
+
+.selectItem > a {
+    display: block;
+    width: 100%;
+    color: darkgray;
+    text-decoration: none;
+    padding: 3px;
+}
+
+.selectHover {
+    background: lightgray;
 }

--- a/src/components/SchemaDocsView.css.flow.js
+++ b/src/components/SchemaDocsView.css.flow.js
@@ -2,3 +2,9 @@
 
 declare export var wrapper: string;
 declare export var container: string;
+declare export var content: string;
+declare export var sidenav: string;
+declare export var selectInput: string;
+declare export var selectList: string;
+declare export var selectItem: string;
+declare export var selectHover: string;

--- a/src/components/SchemaDocsView.js
+++ b/src/components/SchemaDocsView.js
@@ -1,68 +1,150 @@
 // @flow
 
 import React from 'react';
+import {Typeahead} from 'react-typeahead';
 
-import { Schema, Type, ObjectType, InterfaceType, EnumType, ScalarType, InputObjectType } from '../model';
+import { Schema, Type, ObjectType, InterfaceType, UnionType, EnumType, ScalarType, InputObjectType } from '../model';
 import { getReferencesInSchema } from '../schemaWalker';
 
-import { ObjectDocsView, InterfaceDocsView, EnumDocsView, ScalarDocsView, InputObjectDocsView } from './TypeDocsViews';
+import { ObjectDocsView, InterfaceDocsView, UnionDocsView, EnumDocsView, ScalarDocsView, InputObjectDocsView } from './TypeDocsViews';
+import SectionView from './SectionView';
+import SideNavSectionView from './SideNavSectionView';
 
 import * as StyleSheet from  './SchemaDocsView.css';
 
 export class SchemaDocsView extends React.Component {
+    constructor(props: any) {
+        super(props);
+        (this: any).handleSelect = this.handleSelect.bind(this);
+    }
+
     props: {
-        schema: Schema,
+        schema: Schema
     };
+
+    handleSelect(name: string) {
+        location.hash = `#${name}`;
+    }
 
     render() {
         const types = getReferencesInSchema(this.props.schema).map(tn => this.props.schema.types[tn]);
-        const components = [];
+        const sections = {
+            schema: {name: 'Schema', items: []},
+            objects: {name: 'Object Types', items: []},
+            inputs: {name: 'Input Types', items: []},
+            unions: {name: 'Unions', items: []},
+            interfaces: {name: 'Interfaces', items: []},
+            enums: {name: 'Enums', items: []},
+            scalars: {name: 'Scalars', items: []},
+        };
+        const options = [];
 
         types.forEach((t: Type) => {
             if (t instanceof ObjectType) {
-                components.push(
-                    <ObjectDocsView
+                const component = (
+                  <ObjectDocsView
+                    key={t.name}
+                    type={t}
+                    titleOverride={this.titleOverrideFor(t)}
+                  />);
+                if (t === this.props.schema.getQueryType() ||
+                  t === this.props.schema.getMutationType()) {
+                    sections.schema.items.push({name: t.name, component: component});
+                    options.push(t.name);
+                } else {
+                    sections.objects.items.push({name: t.name, component: component});
+                    options.push(t.name);
+                }
+            }
+            if (t instanceof UnionType) {
+                options.push(t.name);
+                sections.unions.items.push({name: t.name, component:
+                    (<UnionDocsView
                         key={t.name}
                         type={t}
-                        titleOverride={this.titleOverrideFor(t)}
-                    />);
+                    />)});
             }
             if (t instanceof InterfaceType) {
-                components.push(
-                    <InterfaceDocsView
+                options.push(t.name);
+                sections.interfaces.items.push({name: t.name, component:
+                    (<InterfaceDocsView
                         key={t.name}
                         type={t}
-                    />);
+                    />)});
             }
             if (t instanceof EnumType) {
-                components.push(
-                    <EnumDocsView
+                options.push(t.name);
+                sections.enums.items.push({name: t.name, component:
+                    (<EnumDocsView
                         key={t.name}
                         type={t}
-                    />);
+                    />)});
             }
             if (t instanceof InputObjectType) {
-                components.push(
-                    <InputObjectDocsView
+                options.push(t.name);
+                sections.inputs.items.push({name: t.name, component:
+                    (<InputObjectDocsView
                         key={t.name}
                         type={t}
-                    />);
+                    />)});
             }
-        });
-        types.forEach((t: Type) => {
             if (t instanceof ScalarType) {
-                components.push(
-                    <ScalarDocsView
+                options.push(t.name);
+                sections.scalars.items.push({name: t.name, component:
+                    (<ScalarDocsView
                         key={t.name}
                         type={t}
-                    />);
+                    />)});
             }
         });
 
+        Object.keys(sections).forEach((key) => {
+            const section = sections[key];
+            section.items.sort((itemA, itemB) => {
+                if (itemA.name.toUpperCase() < itemB.name.toUpperCase()) {
+                    return -1;
+                }
+                if (itemA.name.toUpperCase() > itemB.name.toUpperCase()) {
+                    return 1;
+                }
+                return 0;
+            });
+        });
+
+        const customClasses = {
+            input: StyleSheet.selectInput,
+            results: StyleSheet.selectList,
+            listItem: StyleSheet.selectItem,
+            hover: StyleSheet.selectHover,
+        };
+
         return (
             <div className={StyleSheet.wrapper}>
-                <div className={StyleSheet.container}>
-                    {components}
+                <div className={StyleSheet.sidenav}>
+                    <Typeahead
+                        options={options}
+                        maxVisible={6}
+                        placeholder="Search types"
+                        customClasses={customClasses}
+                        onOptionSelected={this.handleSelect}
+                    />
+                    <br />
+                    {Object.keys(sections).map( (key) => {
+                        const section = sections[key];
+                        return (section.items.length > 0) ? (
+                            <SideNavSectionView name={section.name} items={section.items}/>
+                        ) : '';
+                    })}
+                </div>
+                <div className={StyleSheet.content}>
+                    <div className={StyleSheet.container}>
+                        {Object.keys(sections).map( (key) => {
+                            const section = sections[key];
+                            return (section.items.length > 0) ? (
+                                <SectionView name={section.name} items={section.items}/>
+                            ) : '';
+                        })}
+                    </div>
                 </div>
             </div>
         );
@@ -70,7 +152,7 @@ export class SchemaDocsView extends React.Component {
 
     titleOverrideFor(t: Type): ?string {
         if (t === this.props.schema.getQueryType()) {
-            return 'Root query';
+            return 'Query';
         }
         if (t === this.props.schema.getMutationType()) {
             return 'Mutations';

--- a/src/components/SectionView.css
+++ b/src/components/SectionView.css
@@ -1,0 +1,5 @@
+@import "./_normalize.css";
+
+.section {
+    padding: 10px;
+}

--- a/src/components/SectionView.css.flow.js
+++ b/src/components/SectionView.css.flow.js
@@ -1,0 +1,3 @@
+// @flow
+
+declare export var section: string;

--- a/src/components/SectionView.js
+++ b/src/components/SectionView.js
@@ -1,0 +1,15 @@
+import React from 'react';
+
+import * as StyleSheet from  './SectionView.css';
+
+export default class SectionView extends React.Component {
+    render() {
+        return (
+        <div className={StyleSheet.section}>
+            <a name={this.props.name} />
+            <h2>{this.props.name}</h2>
+            {this.props.items.map((item) => item.component)}
+        </div>
+        );
+    }
+}

--- a/src/components/SideNavSectionView.css
+++ b/src/components/SideNavSectionView.css
@@ -1,0 +1,30 @@
+@import "./_normalize.css";
+
+.sidenavSection {
+    width: 100%;
+}
+
+.sectionLink,
+.typeLink {
+    width: 100%;
+}
+
+.sectionLink > a,
+.typeLink > a {
+    display: block;
+    width: 100%;
+    height: 100%;
+    padding: 10px;
+    text-decoration: none;
+    color: darkgray;
+}
+
+.sectionLink > a {
+    text-transform: uppercase;
+    color: #222222;
+}
+
+.typeLink:hover,
+.sectionLink:hover {
+    background: lightgray;
+}

--- a/src/components/SideNavSectionView.css.flow.js
+++ b/src/components/SideNavSectionView.css.flow.js
@@ -1,0 +1,5 @@
+// @flow
+
+declare export var sidenavSection: string;
+declare export var sectionLink: string;
+declare export var typeLink: string;

--- a/src/components/SideNavSectionView.js
+++ b/src/components/SideNavSectionView.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import * as StyleSheet from  './SideNavSectionView.css';
+
+export default class SideNavSectionView extends React.Component {
+    render() {
+        return (
+            <div className={StyleSheet.sidenavSection}>
+                <div className={StyleSheet.sectionLink}>
+                    <a href={`#${this.props.name}`}>{this.props.name}</a>
+                </div>
+                {this.props.items.map((item) => {
+                    return (
+                        <div className={StyleSheet.typeLink}>
+                            <a href={`#${item.name}`}>
+                                &nbsp;&nbsp;{item.name}
+                            </a>
+                        </div>
+                    );
+                })}
+            </div>
+        );
+    }
+}

--- a/src/components/TypeDocsViews.js
+++ b/src/components/TypeDocsViews.js
@@ -2,7 +2,7 @@
 
 import React from 'react';
 
-import { ObjectType, InterfaceType, EnumType, ScalarType, InputObjectType, Field, TypeRef, EnumValue } from '../model';
+import { ObjectType, InterfaceType, UnionType, EnumType, ScalarType, InputObjectType, Field, TypeRef, EnumValue } from '../model';
 
 import { DescriptionView } from './DescriptionView';
 import { FieldView } from './FieldView';
@@ -30,6 +30,23 @@ export class ObjectDocsView extends React.Component {
                 {renderInterfaces(type.interfaces)}
                 {renderFields(type.fields)}
             </div>
+        );
+    }
+}
+
+export class UnionDocsView extends React.Component {
+    props: {
+        type: UnionType,
+    };
+
+    render() {
+        const type = this.props.type;
+        return (
+          <div className={StyleSheet.type}>
+            {renderTitle(type.name)}
+            {renderDescription(type.description)}
+            {renderPossibleTypes(type.possibleTypes)}
+          </div>
         );
     }
 }
@@ -107,10 +124,10 @@ export class InputObjectDocsView extends React.Component {
 
 function renderTitle(typeName: string, titleOverride: ?string = null) {
     return (
-        <h2 className={StyleSheet.heading}>
+        <h3 className={StyleSheet.heading}>
             <a name={typeName} />
             {titleOverride || typeName}
-        </h2>
+        </h3>
     );
 }
 
@@ -156,6 +173,26 @@ function renderInterfaces(interfaces: Array<TypeRef>) {
                     </li>)}
             </ul>
         </div>
+    );
+}
+
+function renderPossibleTypes(possibleTypes: Array<TypeRef>) {
+    if (!possibleTypes.length) {
+        return null;
+    }
+
+    return (
+    <div>
+        <div className={StyleSheet.subHeading}>
+            Possible Types
+        </div>
+        <ul className={StyleSheet.interfacesList}>
+            {possibleTypes.map((r, i) =>
+                <li key={i}>
+                    <TypeRefView key={i} typeRef={r} />
+                </li>)}
+        </ul>
+    </div>
     );
 }
 

--- a/src/components/_base.css
+++ b/src/components/_base.css
@@ -1,3 +1,16 @@
+html::-webkit-scrollbar
+{
+    width: 12px;
+    background-color: #f1f1f1;
+}
+
+html::-webkit-scrollbar-thumb
+{
+    border-radius: 10px;
+    -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,.3);
+    background-color: #d0d0d0;
+}
+
 :root {
     --typeNameColor: #007400;
 }
@@ -25,6 +38,7 @@
 
 .typeName {
     color: var(--typeNameColor);
+    text-decoration: none;
 }
 
 .typeLink,
@@ -32,4 +46,5 @@
 .typeLink:hover,
 .typeLink:visited {
     color: var(--typeNameColor);
+    text-decoration: none;
 }

--- a/src/model.js
+++ b/src/model.js
@@ -6,6 +6,7 @@ export const TYPE_KINDS = [
     'OBJECT',
     'ENUM',
     'INPUT_OBJECT',
+    'UNION',
 ];
 
 export type TypeId = string;
@@ -79,6 +80,8 @@ export class Type {
             return new EnumType(introspectionType);
         } else if (introspectionType.kind === 'INPUT_OBJECT') {
             return new InputObjectType(introspectionType);
+        } else if (introspectionType.kind === 'UNION') {
+            return new UnionType(introspectionType);
         } else {
             throw new Error('Unsupported type kind: ' + introspectionType.kind);
         }
@@ -116,6 +119,21 @@ export class ObjectType extends Type {
         } else {
             this.interfaces = [];
         }
+    }
+}
+
+export class UnionType extends Type {
+    possibleTypes: Array<TypeRef>;
+
+    constructor(introspectionType: any) {
+        pre: {
+            introspectionType.kind === 'UNION';
+            Array.isArray(introspectionType.possibleTypes);
+        }
+
+        super(introspectionType);
+
+        this.possibleTypes = introspectionType.possibleTypes.map(r => TypeRef.fromIntrospectionRef(r));
     }
 }
 

--- a/src/schemaWalker.js
+++ b/src/schemaWalker.js
@@ -1,6 +1,6 @@
 // @flow
 
-import { Type, Schema, ObjectType, InterfaceType, InputObjectType, Field, TypeRef, NonNullTypeRef, NamedTypeRef, ListTypeRef } from './model';
+import { Type, Schema, ObjectType, InterfaceType, UnionType, InputObjectType, Field, TypeRef, NonNullTypeRef, NamedTypeRef, ListTypeRef } from './model';
 import type { TypeId } from './model';
 
 
@@ -49,6 +49,10 @@ function getReferencesInType(type: Type): Bag {
 
     if (type instanceof InterfaceType) {
         type.fields.forEach(f => getReferencesInField(f, refs));
+        type.possibleTypes.forEach(r => addTypeRefToBag(r, refs));
+    }
+
+    if (type instanceof UnionType) {
         type.possibleTypes.forEach(r => addTypeRefToBag(r, refs));
     }
 


### PR DESCRIPTION
I implemented a few additional features to make it easier to find types.

- Implement fix by @f adding support for Union Type - #9
- Group types by definition (Object, Input, Interface, etc.)
- Sort types within each grouping alphabetically
- Add a header for each grouping (with link)
- Add fixed side navigation
- Implement search with autocomplete using react-typeahead